### PR TITLE
fix(fastapi): add /api/v1 prefix and use latest normalize func

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM jinaai/jina:master
 # setup the workspace
 WORKDIR /workspace
 
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
 ADD . .
 
 RUN pip install .

--- a/normalizer/core.py
+++ b/normalizer/core.py
@@ -23,8 +23,8 @@ def filter_executors(executors):
 
 def normalize(
     work_path: 'pathlib.Path',
-    meta: Dict[str] = {'jina': 'master'},
-    env: Dict[str] = {},
+    meta: Dict = {'jina': 'master'},
+    env: Dict = {},
     verbose: bool = False,
     **kwargs,
 ) -> None:
@@ -39,12 +39,17 @@ def normalize(
         print(f'=> The executor repository is located at: {work_path}')
 
         print(f'=> The Jina version info: ')
-        for k, v in meta:
+        for k, v in meta.items():
             print('%20s: -> %20s' % (k, v))
 
         print(f'=> The environment variables: ')
-        for k, v in env:
+        for k, v in env.items():
             print('%20s: -> %20s' % (k, v))
+
+    if not work_path.exists():
+        raise FileNotFoundError(
+            f'The folder "{work_path}" does not exist, can not normalize'
+        )
 
     dockerfile_path = work_path / 'Dockerfile'
     manifest_path = work_path / 'manifest.yml'
@@ -106,10 +111,11 @@ def normalize(
 
             executor, *_ = executors[0]
 
-            try:
-                py_moduels = order_py_modules(py_glob, work_path)
-            except Exception as ex:
-                raise DependencyError
+            py_moduels = py_glob
+            # try:
+            #     py_moduels = order_py_modules(py_glob, work_path)
+            # except Exception as ex:
+            #     raise DependencyError
 
             entrypoint_args = ['jina', 'pod', '--uses', f'{executor}']
             for p in py_moduels:

--- a/server/app.py
+++ b/server/app.py
@@ -20,7 +20,7 @@ def create_app() -> FastAPI:
 
     api_router = APIRouter()
 
-    api_router.include_router(router, tags=['normalizer'], prefix='')
+    api_router.include_router(router, tags=['normalizer'], prefix='/api/v1')
 
     fast_app.include_router(api_router, prefix=API_PREFIX)
 

--- a/server/routes.py
+++ b/server/routes.py
@@ -1,23 +1,22 @@
 import datetime
 from typing import Dict, Optional
-
+from pathlib import Path
 from fastapi import APIRouter
 from fastapi.encoders import jsonable_encoder
 from loguru import logger
 from pydantic import BaseModel
+from pydantic.utils import BUILTIN_COLLECTIONS
 from starlette.requests import Request
 
-from normalizer.main import normalize as _normalize
+from normalizer.core import normalize as _normalize
 
 router = APIRouter()
 
 
 class PackagePayload(BaseModel):
-    package_path: str
-    executor_class: Optional[str] = None
-    executor_py_path: Optional[str] = None
-    config_yaml_path: Optional[str] = None
-    jina_version: str = 'master'
+    package_path: Path
+    meta: Optional[Dict] = {'jina': 'master'}
+    env: Optional[Dict] = {}
 
 
 class NormalizeResult(BaseModel):
@@ -33,10 +32,8 @@ def normalize(
 
     _normalize(
         block_data.package_path,
-        executor_class=block_data.executor_class,
-        executor_py_path=block_data.executor_py_path,
-        config_yaml_path=block_data.config_yaml_path,
-        jina_version=block_data.jina_version,
+        meta=block_data.meta,
+        env=block_data.env,
     )
 
     result = {


### PR DESCRIPTION
The current normalize route is: `https://127.0.0.1:8888/normalizer/api/v1`, e.g.,

```bash
curl -X 'POST' \
  'http://127.0.0.1:8888/normalizer/api/v1/' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "package_path": "case9",
  "meta": {
    "jina": "master"
  },
  "env": {}
}'
```