### PR TITLE
feat: disable pip cache

### DIFF
--- a/normalizer/docker/parser.py
+++ b/normalizer/docker/parser.py
@@ -76,7 +76,8 @@ class ExecutorDockerfile:
         self._parser.content += dedent(
             """\
             # install the third-party requirements
-            RUN pip install --default-timeout=1000 --compile -r requirements.txt
+            RUN pip install --default-timeout=1000 --compile --no-cache-dir \\
+                 -r requirements.txt
 
             """
         )


### PR DESCRIPTION
This adds `--no-cach-dir` option to pip install. As this is a [docker image](https://stackoverflow.com/a/57490475), cache will not be needed, as we will never need to install the same packages again. This can save, in my experience, from 30 to 50 percent of space, so a significant saving.