### PR TITLE
feat: update version

### DIFF
--- a/normalizer/core.py
+++ b/normalizer/core.py
@@ -117,7 +117,7 @@ def prelude(imports: List['Package']):
 
 def normalize(
     work_path: 'pathlib.Path',
-    meta: Dict = {'jina': '2.0.0'},
+    meta: Dict = {'jina': '2'},
     env: Dict = {},
     **kwargs,
 ) -> None:

--- a/normalizer/main.py
+++ b/normalizer/main.py
@@ -9,7 +9,7 @@ from .core import normalize
 
 @click.command()
 @click.argument('path', default='.')
-@click.option('--jina-version', default='2.0.0', help='Specify the jina version.')
+@click.option('--jina-version', default='2', help='Specify the jina version.')
 @click.option('--verbose', '-v', is_flag=True, help='Enables verbose mode.')
 @click.version_option(
     f'{__normalizer_version__} (Jina=v{__iina_version__})',


### PR DESCRIPTION
This makes the default version the latest stable version (from `2.x`). I think this makes more sense than sticking with `2.0.0`, which is probably outdated now could lead to issues