### PR TITLE
fix: include executor folder in py_glob

### DIFF
--- a/normalizer/core.py
+++ b/normalizer/core.py
@@ -341,7 +341,7 @@ def normalize(
     readme_path = work_path / 'README.md'
     requirements_path = work_path / 'requirements.txt'
 
-    py_glob = list(work_path.glob('*.py'))
+    py_glob = list(work_path.glob('*.py')) + list(work_path.glob('executor/*.py'))
     test_glob = list(work_path.glob('tests/test_*.py'))
 
     completeness = {

--- a/normalizer/models.py
+++ b/normalizer/models.py
@@ -20,11 +20,8 @@ class FuncArgsModel(BaseModel):
     docstring: Optional[str]
 
 
-class EndpointArgsModel(BaseModel):
+class EndpointArgsModel(FuncArgsModel):
     name: str
-    args: List[ArgModel]
-    kwargs: List[KWArgModel]
-    docstring: Optional[str]
     requests: str
 
 


### PR DESCRIPTION
fix: include executor folder in py_glob