### PR TITLE
feat(normalizer): merge manifest.yml into config.yml metas

### DIFF
--- a/normalizer/core.py
+++ b/normalizer/core.py
@@ -574,6 +574,7 @@ def normalize(
             if manifest_cfg is not None:
                 config = yaml.safe_load(open(config_path, 'r'))
                 metas_cfg = {**config.get('metas', {}), **manifest_cfg}
+                config['metas'] = metas_cfg
                 with open(config_path, 'w') as f:
                     yaml.dump(config, f, sort_keys=False)
 


### PR DESCRIPTION
This PR will allow the normalizer to merge manifest.yml into config.yml under `metas` key. 
The change is indeed for the Hubble API to not load manifest cfg from two separate places.
