### PR TITLE
fix: skip checking base class when providing jtype

### DIFF
--- a/normalizer/core.py
+++ b/normalizer/core.py
@@ -203,17 +203,17 @@ def inspect_executors(
                 if class_name:
                     if class_name != class_def.name:
                         continue
-
-                base_names = []
-                for base_class in class_def.bases:
-                    # if the class looks like class MyExecutor(Executor)
-                    if isinstance(base_class, ast.Name):
-                        base_names.append(base_class.id)
-                    # if the class looks like class MyExecutor(jina.Executor):
-                    if isinstance(base_class, ast.Attribute):
-                        base_names.append(base_class.attr)
-                if 'Executor' not in base_names:
-                    continue
+                else:
+                    base_names = []
+                    for base_class in class_def.bases:
+                        # if the class looks like class MyExecutor(Executor)
+                        if isinstance(base_class, ast.Name):
+                            base_names.append(base_class.id)
+                        # if the class looks like class MyExecutor(jina.Executor):
+                        if isinstance(base_class, ast.Attribute):
+                            base_names.append(base_class.attr)
+                    if 'Executor' not in base_names:
+                        continue
 
                 init = None
                 endpoints = []

--- a/tests/cases/executor_5/foo.py
+++ b/tests/cases/executor_5/foo.py
@@ -1,6 +1,7 @@
-from jina import Executor, requests
+from jina import requests
+from jina import Executor as OtherBaseName
 
-class Executor5(Executor):
+class Executor5(OtherBaseName):
     @requests
     def foo(self):
         pass


### PR DESCRIPTION
If the user has already defined `jtype` in `config.yaml`, there is no need to guess the class name. 

Resolves: https://github.com/jina-ai/hubble/issues/640